### PR TITLE
chore(ci): bump actions to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2.7
   test:
@@ -22,11 +22,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check out
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
       - name: go test
         run: go test -v -race -coverprofile=profile.cov ./...
       - name: Send coverage


### PR DESCRIPTION
Updates: actions/checkout@v4→v7, actions/setup-go@v5→v6